### PR TITLE
Add Terraform provider internal CI/CD

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,63 +1,103 @@
 pipeline {
     agent none
+    parameters {
+        // Allow user to select the branch to run against
+        string(name: 'GIT_BRANCH', defaultValue: 'master')
+        // The UUID of the credentials used to fetch the git repos
+        string(name: 'GIT_CREDS_GUID', defaultValue: '')
+        // Allow users to select the version of Terraform to test against
+        string(name: 'TERRAFORM_VERSION', defaultValue: '0.11.14')
+        // The Git repository for the Terraform Provider
+        string(name: 'GIT_REPO_URL', defaultValue: 'https://github.com/CloudBoltSoftware/terraform-provider-cloudbolt.git')
+        // The Git repository for the Go SDK
+        string(name: 'SDK_REPO_URL', defaultValue: 'https://github.com/CloudBoltSoftware/cloudbolt-go-sdk.git')
+        // The CloduBolt host we will be running the tests against
+        string(name: 'CLOUDBOLT_HOST', defaultValue: '127.0.0.1')
+        // The credentials used to authenticate with that host
+        string(name: 'CLOUDBOLT_USERNAME', defaultValue: 'TerraformUser01')
+        string(name: 'CLOUDBOLT_PASSWORD', defaultValue: 'TerraformPassword01')
+        // Host and Port can be overridden, although they probably won't need to be
+        string(name: 'CLOUDBOLT_PORT', defaultValue: '443')
+        string(name: 'CLOUDBOLT_PROTOCOL', defaultValue: 'https')
+    }
+    environment {
+        GO_SDK_DIR = "./cloudbolt-go-sdk"
+        TERRAFORM_PROVIDER_DIR = "./terraform-provider-cloudbolt"
+        TERRAFORM_PROVIDER_BIN_NAME = "terraform-provider-cloudbolt"
+        TEST_DIR = "./terraform-provider-cloudbolt/examples/order-blueprint"
+    }
     stages {
-        stage('Cleanup') {
-            agent any
-            steps {
-                sh 'rm -rf /var/jenkins_home/go/src/github.com/cloudboltsoftware/terraform-provider-cloudbolt*'
-                sh 'rm -rf /var/jenkins_home/go/src/github.com/cloudboltsoftware/cloudbolt-go-sdk*'
-            }
-        }
-        stage('Build-provider') {
+        stage('Build') {
             agent {
-                docker { image 'golang' }
+                // Building happens in the Alpine Golang container
+                // We don't _need_ alpine, but the Terraform container is also alpine,
+                // and we good to keep them as close as possible
+                docker { image 'golang:alpine' }
+            }
+            environment {
+                // Set the Go environment variables to be relative to the workspace directory
+                GOPATH = "${env.WORKSPACE}/go"
+                GOCACHE = "${env.WORKSPACE}/go/.cache"
             }
             steps {
-                withEnv(['GOPATH=/var/jenkins_home/go', 'GOCACHE=/var/jenkins_home/go/.cache']) {
-                    git credentialsId: '843338a5-615e-47be-a267-6e7c9b266843', url: 'https://github.com/CloudBoltSoftware/terraform-provider-cloudbolt.git'
-                    sh 'cp -r . $GOPATH/src/github.com/cloudboltsoftware/terraform-provider-cloudbolt'
-                    git credentialsId: '843338a5-615e-47be-a267-6e7c9b266843', url: 'https://github.com/CloudBoltSoftware/cloudbolt-go-sdk.git'
-                    sh 'cp -r . $GOPATH/src/github.com/cloudboltsoftware/cloudbolt-go-sdk'
-                    sh 'echo "replace github.com/cloudboltsoftware/cloudbolt-go-sdk => ../cloudbolt-go-sdk" >> "$GOPATH/src/github.com/cloudboltsoftware/terraform-provider-cloudbolt/go.mod"'
-                    dir("$GOPATH/src/github.com/cloudboltsoftware/terraform-provider-cloudbolt") {
-                        sh 'go build -o terraform-provider-cloudbolt'
-                        sh 'mv terraform-provider-cloudbolt /var/jenkins_home/.terraform.d/plugins'
-                    }
+                // Clone the CloudBolt Go SDK to build against
+                dir("${env.GO_SDK_DIR}") {
+                    git credentialsId: "${params.GIT_CREDS_GUID}", url: "${params.SDK_REPO_URL}", poll: false
+                }
+                // Clone the Terraform Provider
+                dir("${env.TERRAFORM_PROVIDER_DIR}") {
+                    git credentialsId: "${params.GIT_CREDS_GUID}", url: "${params.GIT_REPO_URL}", branch: "${params.GIT_BRANCH}", poll: false
+
+                    // Override the version of the Go SDK in `go.mod` to be the local checkout
+                    sh "echo \"replace github.com/cloudboltsoftware/cloudbolt-go-sdk => ../cloudbolt-go-sdk\" >> ./go.mod"
+                    // Build the Terraform Provider
+                    sh "go build -o ${env.TERRAFORM_PROVIDER_BIN_NAME}"
                 }
             }
         }
-        stage('Download-terraform-0-11-14') {
-            agent any
-            when { expression { !fileExists('./terraform_0.11.14_linux_amd64.zip') } }
-            steps {
-                sh 'wget https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip'
-            }
-        }
-        stage('Unzip-terraform') {
-            agent any
-            when { expression { !fileExists('./terraform') } }
-            steps {
-                sh '/usr/bin/unzip terraform_0.11.14_linux_amd64.zip'
-            }
-        }
-        stage('Test') {
-            agent any
-            steps {
-                sh 'cp terraform /var/jenkins_home/go/src/github.com/cloudboltsoftware/terraform-provider-cloudbolt/examples/order-blueprint/'
-                dir('/var/jenkins_home/go/src/github.com/cloudboltsoftware/terraform-provider-cloudbolt/examples/order-blueprint/') {
-                    withEnv(['TF_VAR_CB_HOST=docker.for.mac.localhost']) {
-                        sh 'cp terraform.tfvars.dist terraform.tfvars'
-                        sh './terraform init'
-                        sh './terraform plan -var "CB_HOST=$TF_VAR_CB_HOST"'
-                        sh './terraform apply -auto-approve -var "CB_HOST=$TF_VAR_CB_HOST"'
-                        sh './terraform apply -auto-approve -var "CB_HOST=$TF_VAR_CB_HOST"'
-                        sh './terraform show'
-                        sh './terraform destroy -auto-approve -var "CB_HOST=$TF_VAR_CB_HOST"'
-                        sh './terraform destroy -auto-approve -var "CB_HOST=$TF_VAR_CB_HOST"'
-                    }
+        stage('Test: Order Blueprint') {
+            agent {
+                docker {
+                    // Run the provider in the Terraform container
+                    image "hashicorp/terraform:${params.TERRAFORM_VERSION}"
+                    // Override the default Docker Entrypoint with an empty one
+                    // so we can treat this like a normal run environment
+                    // Otherwise we every `sh` step must be a `terraform` sub-command
+                    args '--entrypoint='
                 }
-            }            
+            }
+            environment {
+                // Pass the parameters though to Terraform as environment variables
+                TF_VAR_CB_HOST          = "${params.CLOUDBOLT_HOST}"
+                TF_VAR_CB_PROTOCOL      = "${params.CLOUDBOLT_PROTOCOL}"
+                TF_VAR_CB_PORT          = "${params.CLOUDBOLT_PORT}"
+                TF_VAR_CB_USERNAME      = "${params.CLOUDBOLT_USERNAME}"
+                TF_VAR_CB_PASSWORD      = "${params.CLOUDBOLT_PASSWORD}"
+                // Turn on Verbose logging for Terraform
+                TF_LOG =  "1"
+            }
+            steps {
+                // Copy the Terraform Provider into the test directory
+                sh "cp -f ${env.TERRAFORM_PROVIDER_DIR}/${env.TERRAFORM_PROVIDER_BIN_NAME} ${env.TEST_DIR}"
+
+                // Run tests in terraform-provider-cloudbolt/examples/order-blueprint
+                dir("${env.TEST_DIR}") {
+                    // Init
+                    sh 'terraform init'
+                    // Plan
+                    sh 'terraform plan'
+                    // Apply twice
+                    // Applying the second time should be a no-op
+                    sh 'terraform apply -auto-approve'
+                    sh 'terraform apply -auto-approve'
+                    // Show
+                    sh 'terraform show'
+                    // Destroy twice
+                    // Destroying the second time should be a no-op
+                    sh 'terraform destroy -auto-approve'
+                    sh 'terraform destroy -auto-approve'
+                }
+            }
         }
     }
 }
-


### PR DESCRIPTION
# Development Prerequisites
- **Developer:** Pete G
- **Partner:** Elijah V
- **Jira Story:** [DEV-12937](https://cloudbolt.atlassian.net/browse/DEV-12937)

## Summary of Proposed Changes
This work provides a Jenkins-based CI/CD workflow to both build and test the CloudBolt Terraform Resource Provider. As part of that effort, it uses a golang docker container to build the provider binary, downloads the appropriate compatible version of Terraform, arranges the resources as needed on the filesystem, and uses the bundled order-blueprint example to verify that the provider is functioning correctly.

## Special Instructions or Notes
Due to a number of environmental issues that are in flux, this PR is somewhat more of a proof-of-concept than it is something ready to GTM. The system so far has been developed against a Dockerized Jenkins server, so there are a number of setup prerequisites for development as it exists now. We are also currently using a private git repo, so everything in the Jenkinsfile and in this document that have anything to do with git credentials will be removed at some point in the future (more info below).

**Install and configure Jenkins docker container**
- Reference: https://getintodevops.com/blog/the-simple-way-to-run-docker-in-docker-for-ci
- use official Jenkins image file: https://hub.docker.com/r/jenkins/jenkins/
- run it and mount docker.sock from host to container: `docker run -p 80:8080 -v /var/run/docker.sock:/var/run/docker.sock --name jenkins jenkins/jenkins:lts`

**In the Jenkins container**
(to enter the container: `docker exec -u root -it <container_id>  bash`)
- install docker ce binaries in the container:

```
apt-get update && \
apt-get -y install apt-transport-https \
     ca-certificates \
     curl \
     gnupg2 \
     software-properties-common && \
curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg > /tmp/dkey; apt-key add /tmp/dkey && \
add-apt-repository \
   "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
   $(lsb_release -cs) \
   stable" && \
apt-get update && \
apt-get -y install docker-ce
```
- add jenkins user to root group: `gpasswd -a jenkins root`

**In the Jenkins UI**
- set up Jenkins and add a multibranch pipeline called "Terraform Provider for Cloudbolt"
- Select "Add Source" under the Branch Sources heading
- In the Branch Sources section, add your github credentials
- Also in the Branch Sources section, point it at [the git repo](https://github.com/CloudBoltSoftware/terraform-provider-cloudbolt.git) 
- Navigate to Jenkins->Credentials to find the GUID for the credentials you added.
- EDIT, COMMIT, AND PUSH THE JENKINSFILE TO GITHUB TO REPLACE THE CREDENTIALS GUID ALREADY ENTERED IN THE 2 GIT DIRECTIVES. Sorry, couldn't really find a good way to pull that out as a configurable value, and didn't want to spend too much time on it since the credentials won't be required in the future.
- select "Scan Repository Now" and let it discover the Jenkinsfile in this branch (this may not be necessary as I think it scans the repo right after you configure the Branch Sources, but just in case...)
- drill down through the project and into the branch entry to find the "Build Now" button

**In the future**
- The eventual home for this work will be a standalone Jenkins server, so be aware that the Docker-specific aspects of the Jenkins setup are temporary. The only use of Docker in this system in the future should be the continued use of the golang container to build the provider.
- The [terraform provider repo](https://github.com/CloudBoltSoftware/terraform-provider-cloudbolt) will eventually be public, so the git credentials details included here are also temporary.
- This is a first pass at a Jenkinsfile produced by a rank Jenkins novice. I have no doubt there is plenty of room for improvement in the pipeline beyond removing the aforementioned pieces as they become obsolete. The monolithic 'Test' stage, for example, might be split into multiple stages for better test granularity and readability (e.g., a stage for each of init, plan, apply, show, and destroy).
- The checkout of the cloudbolt-go-sdk and the `echo` that follows it in the 'Build-provider' stage can also eventually be removed as it will eventually be handled transparently by the go build process. That dependency is also in a private repository at this point, so the extra hoops are necessary until that repo is also made public.
- It might also be nice to be able to specify the desired version of terraform in a more flexible manner than hard-coding it into the Jenkinsfile.
- I simply couldn't get the environment variable override for `CB_HOST` to work, even whenit was exported in the documented TF_VAR_name format. I retained the environment variable declaration in the 'Test' stage, but had to take the extra step to pass the value to Terraform using the `-var` command line option. It would be ideal to allow the host to be configured somewhere (perhaps in Jenkins itself) so that public end-users can supply their own hostname.
- The same is true for any of the other hard-coded values and variables currently in the Jenkinsfile (paths in the 'Cleanup' stage, GOPATH, GOCACHE).
- Because this is itself a test of the provider build process, no automated tests are being created or modified for this work.
- Slack integration is mentioned in the original story and would be great to add in the future.
- It might also be nice to add a build step that copies the provider binary to someplace publicly accessible (also mentioned in the original story).

# Developer Merge Criteria
_Please fill out all relevant sections below before moving the story to 'In Review' in Jira_

### Required Steps
- [x] Review branch for leftover comments and extraneous code
- [x] Confirm that no additional migrations are required (utilities/check_migration.py)

### Integration (What other code does this affect?)
- [ ] API updated (ex. if any fields were added to models, especially if object is exported/imported)
- [ ] Checked for duplicate migration numbers and `makemigrations --merge` if any are found
- [ ] Changes made to packaging, requirements, or the upgrader (including migrations/cb_minimal)
    - Upgrades were tested (Docker: run_upgrader.sh, Elysium: dev_tools/test_cb_upgrade.sh)
    - Check that developer tooling (update.py or Elysium equivalent) works with the changes
- [ ] Feature added to global search (if part of a admin page like Misc Settings) in cb_minimal.py
- [ ] Changes made to high-risk areas (jobengine, etc.)

### Testing (How was the branch tested?)
##### Automated Tests
- [x] No automated tests added
This is a set of tests, so no tests to test the tests will be added as far as I know.

### Documentation (Will people know how to use it?)
- [ ] Release notes were updated (in the repo at ~/cloudbolt/docs/src/release-notes.rst)
- [ ] Product documentation was created or updated

# Partner Merge Criteria
_Please complete all criteria in this section before moving the story to 'QA' in Jira_

- [ ] The destination branch was recently merged into this branch
- [ ] Reviewed all code and documentation changes
- [ ] Reviewed Automated and/or TestRail tests, and executed the test plan
- [ ] Performed negative testing (tried to break the feature)
    - Verified that permissions are enforced appropriately (eg. use feature as a non super-user)
- [ ] Approve the pull request ("Review changes" -> "Approve")
- [ ] Merged the pull request & deleted the branch
- [ ] Confirmed that FrequentCIT succeeded
- [ ] Notify the team if packages have been updated (#dev on Slack)
