### PR TITLE
[ENG-21991] - Parameters no longer required on deployment items

### DIFF
--- a/docs/resources/bp_instance.md
+++ b/docs/resources/bp_instance.md
@@ -67,12 +67,12 @@ resource "cloudbolt_bp_instance" "mycbresource" {
 Required:
 
 - `name` (String) The reference name for the blueprint deployment item
-- `parameters` (Map of String) Parameter Name/Value pair
 
 Optional:
 
 - `environment` (String) The relative API URL path for the CloudBolt Environment
 - `osbuild` (String) The relative API URL path for the CloudBolt OS Build
+- `parameters` (Map of String) Parameter Name/Value pair
 
 
 <a id="nestedatt--servers"></a>

--- a/internal/service/cmp/resource_bp_instance.go
+++ b/internal/service/cmp/resource_bp_instance.go
@@ -70,7 +70,7 @@ func ResourceBPInstance() *schema.Resource {
 						},
 						"parameters": {
 							Type:        schema.TypeMap,
-							Required:    true,
+							Optional:    true,
 							Description: "Parameter Name/Value pair",
 						},
 					},


### PR DESCRIPTION
Updated resource_bp_instance resource schema to make parameters optional for deployment items.