### PR TITLE
devops/use github action template from hashicorp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,13 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Unshallow
+
+      - name: Unshallow
         run: git fetch --prune --unshallow
-      -
-        name: Set up Go
+
+      - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
@@ -37,7 +36,7 @@ jobs:
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2.9.1
+        uses: goreleaser/goreleaser-action@v3.0.0
         with:
           version: latest
           args: release --rm-dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,16 +29,14 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      -
-        name: Import GPG key
+
+      - uses: crazy-max/ghaction-import-gpg@v5.1.0
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
-        env:
-          # These secrets will need to be configured for the repository:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
-      -
-        name: Run GoReleaser
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.9.1
         with:
           version: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,41 +1,35 @@
-# This GitHub action can publish assets for release when a tag is created.
-# Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
-#
-# This uses an action (hashicorp/ghaction-import-gpg) that assumes you set your 
-# private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
-# secret. If you would rather own your own GPG handling, please fork this action
-# or use an alternative one for key handling.
-#
-# You will need to pass the `--batch` flag to `gpg` in your signing step 
-# in `goreleaser` to indicate this is being used in a non-interactive mode.
-#
 name: release
 on:
   push:
     tags:
       - 'v*'
+permissions:
+  contents: write
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      -
+        name: Checkout
         uses: actions/checkout@v3
-
-      - name: Unshallow
+      -
+        name: Unshallow
         run: git fetch --prune --unshallow
-
-      - name: Set up Go
+      -
+        name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
-
-      - uses: crazy-max/ghaction-import-gpg@v5.1.0
+          go-version-file: 'go.mod'
+          cache: true
+      -
+        name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v5
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-
-      - name: Run GoReleaser
+          passphrase: ${{ secrets.PASSPHRASE }}
+      -
+        name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3.0.0
         with:
           version: latest


### PR DESCRIPTION
- use upstream gpg action as indicated by hashicorp deprecation notice
- update go releaser action
- update go releaser action
