### PR TITLE
[ENG-24939] - Added Terraform Update Support For Resources

### DIFF
--- a/internal/service/cmp/resource_bp_instance.go
+++ b/internal/service/cmp/resource_bp_instance.go
@@ -487,7 +487,7 @@ func resourceBPInstanceUpdate(ctx context.Context, d *schema.ResourceData, m int
 	}
 
 	requestTimeout := d.Get("request_timeout").(int)
-	if d.HasChange("deployment_item") || d.HasChange("deployment_item") {
+	if d.HasChange("parameters") || d.HasChange("deployment_item") {
 		apiClient := m.(*cbclient.CloudBoltClient)
 		actionPath, geterr := getResourceActionPath(apiClient, d.Id(), "Terraform Provider Update")
 		if geterr != nil {

--- a/internal/service/cmp/resource_bp_instance.go
+++ b/internal/service/cmp/resource_bp_instance.go
@@ -481,9 +481,15 @@ func resourceBPInstanceRead(ctx context.Context, d *schema.ResourceData, m inter
 }
 
 func resourceBPInstanceUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	instanceType := d.Get("instance_type").(string)
 	if instanceType != "Resource" {
-		return resourceBPInstanceRead(ctx, d, m)
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "The CloudBolt provider does not support Terraform config updates for Servers.",
+		})
+		return diags
 	}
 
 	requestTimeout := d.Get("request_timeout").(int)
@@ -495,7 +501,11 @@ func resourceBPInstanceUpdate(ctx context.Context, d *schema.ResourceData, m int
 		}
 
 		if actionPath == "" {
-			return resourceBPInstanceRead(ctx, d, m)
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "CloudBolt blueprint does not have a management action named \"Terraform Provider Update\", this action is required to apply terraform configuration changes.",
+			})
+			return diags
 		}
 
 		tfConfigParams := make(map[string]interface{}, 0)


### PR DESCRIPTION
Added functionality to support updates driven by terraform config changes. changes are applied to the CloudBolt resource by adding a Management Action named "Terraform Provider Update" to the bluepr int that the was used to create the resource.